### PR TITLE
fix: standardize all Dockerfiles to use Go 1.21

### DIFF
--- a/clean-ingestion-go/Dockerfile
+++ b/clean-ingestion-go/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go application
-FROM golang:1.24-alpine AS builder
+FROM golang:1.21-alpine AS builder
 
 WORKDIR /app
 

--- a/data-ingestion-go/Dockerfile
+++ b/data-ingestion-go/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go application
-FROM golang:1.24-alpine AS builder
+FROM golang:1.21-alpine AS builder
 
 WORKDIR /app
 

--- a/processing-engine-go/Dockerfile
+++ b/processing-engine-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.21-alpine AS build
 
 # Install required dependencies (combining apk commands for better layer caching)
 RUN apk update && apk add --no-cache git ca-certificates tzdata wget

--- a/storage-layer-go/Dockerfile
+++ b/storage-layer-go/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.21-alpine AS builder
 
 # Install SQLite with a specific gcc version to avoid build issues
 RUN apk update && \

--- a/tenant-management-go/Dockerfile
+++ b/tenant-management-go/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS build
+FROM golang:1.21-alpine AS build
 
 # Set working directory
 WORKDIR /app

--- a/visualization-go/Dockerfile
+++ b/visualization-go/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS build
+FROM golang:1.21-alpine AS build
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
- Updated all service Dockerfiles from Go 1.24 to Go 1.21
- Ensures consistency with go.mod files and CI/CD workflow
- Resolves 'undefined: NewKafkaConsumer' build error in storage layer
- Fixes Docker build compatibility issues across all services

Services updated:
- storage-layer-go: Go 1.24 → 1.21
- tenant-management-go: Go 1.24 → 1.21
- processing-engine-go: Go 1.24 → 1.21
- data-ingestion-go: Go 1.24 → 1.21
- clean-ingestion-go: Go 1.24 → 1.21
- visualization-go: Go 1.24 → 1.21