### PR TITLE
fix: isolate ephemeral runtime contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ Run the complete platform in a disposable Colima VM:
 make -C platform/local e2e-ephemeral
 ```
 
-The command deletes the VM and all container data on success or failure. Use
-the persistent development workflow in the local-platform runbook only when you
-need to inspect a running cluster.
+The command isolates Docker and Kubernetes contexts, then deletes the VM and
+all container data on success or failure. Use the persistent development
+workflow in the local-platform runbook only when you need to inspect a running
+cluster.
 
 Run the production-like Jenkins path:
 

--- a/platform/jenkins/README.md
+++ b/platform/jenkins/README.md
@@ -37,8 +37,10 @@ platform/jenkins/scripts/report-github-status.py \
 
 The ephemeral target creates a dedicated Colima VM, deploys Jenkins to kind,
 builds the immutable agent toolchain, runs PS0/PS1/PS2, then deletes the VM and
-all container data. It defaults to 8 CPUs and 16 GiB because PS2 creates a
-single-node nested functional-test cluster; `JENKINS_COLIMA_CPUS` and
+all container data. Temporary Docker and Kubernetes configuration keeps the
+caller's active contexts unchanged and discards generated context records. The
+VM defaults to 8 CPUs and 16 GiB because PS2 creates a single-node nested
+functional-test cluster; `JENKINS_COLIMA_CPUS` and
 `JENKINS_COLIMA_MEMORY_GIB` can override those values. A clean run can take up
 to two hours on a slow connection because it downloads pinned infrastructure
 images and providers. The outer cluster preloads the integration-agent images

--- a/platform/jenkins/scripts/run-ephemeral.sh
+++ b/platform/jenkins/scripts/run-ephemeral.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 jenkins_dir="$(cd "${script_dir}/.." && pwd)"
 profile="${JENKINS_COLIMA_PROFILE:-investment-platform-jenkins-ephemeral}"
-docker_config=""
+runtime_config_dir=""
 profile_reserved=0
 
 if [[ ! "${profile}" =~ ^investment-platform-jenkins-[a-z0-9][a-z0-9-]*$ ]]; then
@@ -22,8 +22,8 @@ cleanup() {
   if (( profile_reserved != 0 )); then
     colima delete "${profile}" --force --data || status=1
   fi
-  if [[ -n "${docker_config}" ]]; then
-    rm -rf "${docker_config}"
+  if [[ -n "${runtime_config_dir}" ]]; then
+    rm -rf "${runtime_config_dir}"
   fi
   exit "${status}"
 }
@@ -32,8 +32,13 @@ trap 'cleanup 129' HUP
 trap 'cleanup 130' INT
 trap 'cleanup 143' TERM
 
+runtime_config_dir="$(mktemp -d "${TMPDIR:-/tmp}/jenkins-runtime-config.XXXXXX")"
+export DOCKER_CONFIG="${runtime_config_dir}/docker"
+export KUBECONFIG="${runtime_config_dir}/kubeconfig"
+mkdir -p "${DOCKER_CONFIG}"
+unset DOCKER_CONTEXT DOCKER_HOST
+
 profile_reserved=1
-docker_config="$(mktemp -d "${TMPDIR:-/tmp}/jenkins-docker-config.XXXXXX")"
 colima start "${profile}" \
   --activate=false \
   --runtime docker \
@@ -42,7 +47,6 @@ colima start "${profile}" \
   --disk "${JENKINS_COLIMA_DISK_GIB:-50}"
 
 export DOCKER_HOST="unix://${HOME}/.colima/${profile}/docker.sock"
-export DOCKER_CONFIG="${docker_config}"
 
 make -C "${jenkins_dir}" bootstrap
 make -C "${jenkins_dir}" trigger

--- a/platform/local/README.md
+++ b/platform/local/README.md
@@ -20,9 +20,9 @@ stateless Go API with an embedded portfolio-allocation dashboard. Its exact
 calculation, publication, readiness, and replay semantics are defined in the
 [`Slice 3 contract`](../../docs/features/cloud-native-investment-platform/slice-3-analytics-contract.md).
 
-The baseline is intentionally separate from the legacy Minikube, raw-manifest,
-and incomplete Helm deployment paths. Those paths remain untouched until a
-later migration proposal defines their disposition.
+The current baseline replaces the retired Minikube, raw-manifest, and incomplete
+Helm paths. Supported local workflows use kind through the targets documented
+here.
 
 ## Local quality gate
 
@@ -125,7 +125,9 @@ This command creates the reserved `investment-platform-ephemeral` Colima
 profile, bootstraps and verifies all three slices, writes failure diagnostics
 to the host or CI log before cleanup, deletes the kind cluster, and finally
 runs `colima delete --force --data`. It refuses to reuse or delete a
-pre-existing profile.
+pre-existing profile. Temporary Docker and Kubernetes configuration prevents
+the run from changing the caller's active contexts or retaining generated
+context records.
 The tradeoff is that images and charts must be downloaded again on the next
 run; CI is therefore the preferred place for frequent full end-to-end tests.
 

--- a/platform/local/scripts/run-ephemeral.sh
+++ b/platform/local/scripts/run-ephemeral.sh
@@ -13,7 +13,7 @@ memory_gib="${EPHEMERAL_COLIMA_MEMORY_GIB:-8}"
 disk_gib="${EPHEMERAL_COLIMA_DISK_GIB:-30}"
 profile_reserved=0
 runtime_ready=0
-docker_config=""
+runtime_config_dir=""
 
 if [[ ! "${profile}" =~ ^investment-platform-[a-z0-9][a-z0-9-]*$ ]]; then
   printf 'ERROR: EPHEMERAL_COLIMA_PROFILE must start with investment-platform- and contain lowercase letters, digits, or hyphens.\n' >&2
@@ -53,8 +53,8 @@ cleanup() {
     fi
   fi
 
-  if [[ -n "${docker_config}" ]]; then
-    rm -rf "${docker_config}"
+  if [[ -n "${runtime_config_dir}" ]]; then
+    rm -rf "${runtime_config_dir}"
   fi
   if (( original_status == 0 && cleanup_status != 0 )); then
     original_status=${cleanup_status}
@@ -69,8 +69,13 @@ if profile_exists; then
   exit 1
 fi
 
+runtime_config_dir="$(mktemp -d "${TMPDIR:-/tmp}/investment-platform-runtime-config.XXXXXX")"
+export DOCKER_CONFIG="${runtime_config_dir}/docker"
+export KUBECONFIG="${runtime_config_dir}/kubeconfig"
+mkdir -p "${DOCKER_CONFIG}"
+unset DOCKER_CONTEXT DOCKER_HOST
+
 profile_reserved=1
-docker_config="$(mktemp -d "${TMPDIR:-/tmp}/investment-platform-docker-config.XXXXXX")"
 colima start "${profile}" \
   --activate=false \
   --runtime docker \
@@ -79,7 +84,6 @@ colima start "${profile}" \
   --disk "${disk_gib}"
 
 export DOCKER_HOST="unix://${HOME}/.colima/${profile}/docker.sock"
-export DOCKER_CONFIG="${docker_config}"
 runtime_ready=1
 
 run_complete_platform() {

--- a/scripts/ci/test-local-runtime-cleanup.sh
+++ b/scripts/ci/test-local-runtime-cleanup.sh
@@ -5,9 +5,12 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/runtime-cleanup-test.XXXXXX")"
 fake_bin="${test_root}/bin"
 fake_home="${test_root}/home"
+fake_tmp="${test_root}/tmp"
 log_file="${test_root}/commands.log"
 trap 'rm -rf "${test_root}"' EXIT
-mkdir -p "${fake_bin}" "${fake_home}"
+mkdir -p "${fake_bin}" "${fake_home}/.docker" "${fake_home}/.kube" "${fake_tmp}"
+printf 'caller-docker-config\n' >"${fake_home}/.docker/config.json"
+printf 'caller-kubeconfig\n' >"${fake_home}/.kube/config"
 
 cat >"${fake_bin}/fake-command" <<'FAKE'
 #!/usr/bin/env bash
@@ -21,8 +24,24 @@ case "${command_name}" in
       if [[ "${FAKE_PROFILE_PRESENT:-0}" == "1" ]]; then
         printf '%s Running aarch64 4 8GiB 30GiB docker -\n' "${FAKE_PROFILE_NAME}"
       fi
-    elif [[ "${1:-}" == "start" && "${FAKE_FAIL_COLIMA_START:-0}" == "1" ]]; then
-      exit 1
+    elif [[ "${1:-}" == "start" ]]; then
+      if [[ -n "${DOCKER_CONTEXT:-}" || -n "${DOCKER_HOST:-}" ]]; then
+        printf 'inherited Docker override reached Colima start\n' >&2
+        exit 1
+      fi
+      docker_config="${DOCKER_CONFIG:-${HOME}/.docker}"
+      kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
+      if [[ "${docker_config}" == "${HOME}/.docker" ||
+        "${kubeconfig}" == "${HOME}/.kube/config" ]]; then
+        printf 'ephemeral runtime used caller configuration\n' >&2
+        exit 1
+      fi
+      mkdir -p "${docker_config}" "$(dirname "${kubeconfig}")"
+      printf 'generated-colima-context\n' >"${docker_config}/colima-context"
+      printf 'runtime-config %s %s\n' "${docker_config}" "${kubeconfig}" >>"${FAKE_LOG}"
+      if [[ "${FAKE_FAIL_COLIMA_START:-0}" == "1" ]]; then
+        exit 1
+      fi
     fi
     ;;
   docker)
@@ -37,6 +56,11 @@ case "${command_name}" in
     ;;
   make)
     target="${3:-}"
+    if [[ "${target}" == "bootstrap" ]]; then
+      kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
+      mkdir -p "$(dirname "${kubeconfig}")"
+      printf 'generated-kind-context\n' >"${kubeconfig}"
+    fi
     if [[ -n "${FAKE_FAIL_TARGET:-}" && "${target}" == "${FAKE_FAIL_TARGET}" ]]; then
       exit 1
     fi
@@ -50,8 +74,25 @@ done
 
 export PATH="${fake_bin}:${PATH}"
 export HOME="${fake_home}"
+export TMPDIR="${fake_tmp}"
 export FAKE_LOG="${log_file}"
 export FAKE_PROFILE_NAME=investment-platform
+unset DOCKER_CONFIG KUBECONFIG
+
+assert_runtime_config_isolated_and_removed() {
+  local record docker_config kubeconfig runtime_config_dir
+  record="$(grep '^runtime-config ' "${log_file}" | tail -n 1)"
+  read -r _ docker_config kubeconfig <<<"${record}"
+  runtime_config_dir="$(dirname "${docker_config}")"
+
+  [[ "${runtime_config_dir}" == "${TMPDIR}/"* ]]
+  [[ "${docker_config}" == "${runtime_config_dir}/docker" ]]
+  [[ "${kubeconfig}" == "${runtime_config_dir}/kubeconfig" ]]
+  [[ ! -e "${runtime_config_dir}" ]]
+  grep -Fxq 'caller-docker-config' "${HOME}/.docker/config.json"
+  grep -Fxq 'caller-kubeconfig' "${HOME}/.kube/config"
+  [[ ! -e "${HOME}/.docker/colima-context" ]]
+}
 
 if CONFIRM_RUNTIME_CLEANUP= FAKE_PROFILE_PRESENT=1 \
   "${repo_root}/platform/local/scripts/cleanup-runtime.sh" </dev/null 2>/dev/null; then
@@ -80,18 +121,23 @@ grep -q '^colima delete investment-platform --force --data$' "${log_file}"
 FAKE_PROFILE_NAME=investment-platform-ephemeral \
 FAKE_PROFILE_PRESENT=0 \
 FAKE_CLUSTER_PRESENT=1 \
+DOCKER_CONTEXT=caller-context \
+DOCKER_HOST=unix:///caller/docker.sock \
   "${repo_root}/platform/local/scripts/run-ephemeral.sh" >/dev/null
 grep -q '^make -C .*/platform/local bootstrap$' "${log_file}"
 grep -q '^make -C .*/platform/local bootstrap-data-path$' "${log_file}"
 grep -q '^make -C .*/platform/local bootstrap-analytics$' "${log_file}"
 grep -q '^kind delete cluster --name investment-platform$' "${log_file}"
 grep -q '^colima delete investment-platform-ephemeral --force --data$' "${log_file}"
+assert_runtime_config_isolated_and_removed
 
 : >"${log_file}"
 if FAKE_PROFILE_NAME=investment-platform-ephemeral \
   FAKE_PROFILE_PRESENT=0 \
   FAKE_CLUSTER_PRESENT=1 \
   FAKE_FAIL_TARGET=bootstrap-data-path \
+  DOCKER_CONTEXT=caller-context \
+  DOCKER_HOST=unix:///caller/docker.sock \
     "${repo_root}/platform/local/scripts/run-ephemeral.sh" >/dev/null 2>&1; then
   printf 'run-ephemeral ignored a failed platform phase\n' >&2
   exit 1
@@ -102,6 +148,7 @@ if grep -q '^make -C .*/platform/local bootstrap-analytics$' "${log_file}"; then
 fi
 grep -q '^make -C .*/platform/local diagnose$' "${log_file}"
 grep -q '^colima delete investment-platform-ephemeral --force --data$' "${log_file}"
+assert_runtime_config_isolated_and_removed
 
 : >"${log_file}"
 if FAKE_PROFILE_NAME=investment-platform-ephemeral \
@@ -120,6 +167,8 @@ if FAKE_PROFILE_NAME=investment-platform-ephemeral \
   FAKE_PROFILE_PRESENT=0 \
   FAKE_CLUSTER_PRESENT=1 \
   FAKE_FAIL_COLIMA_START=1 \
+  DOCKER_CONTEXT=caller-context \
+  DOCKER_HOST=unix:///caller/docker.sock \
     "${repo_root}/platform/local/scripts/run-ephemeral.sh" >/dev/null 2>&1; then
   printf 'run-ephemeral ignored a failed Colima start\n' >&2
   exit 1
@@ -129,5 +178,30 @@ if grep -q '^kind delete ' "${log_file}"; then
   exit 1
 fi
 grep -q '^colima delete investment-platform-ephemeral --force --data$' "${log_file}"
+assert_runtime_config_isolated_and_removed
 
-printf 'Local ephemeral-runtime lifecycle tests passed.\n'
+: >"${log_file}"
+FAKE_PROFILE_NAME=investment-platform-jenkins-ephemeral \
+FAKE_PROFILE_PRESENT=0 \
+DOCKER_CONTEXT=caller-context \
+DOCKER_HOST=unix:///caller/docker.sock \
+  "${repo_root}/platform/jenkins/scripts/run-ephemeral.sh" >/dev/null
+grep -q '^make -C .*/platform/jenkins bootstrap$' "${log_file}"
+grep -q '^make -C .*/platform/jenkins trigger$' "${log_file}"
+grep -q '^colima delete investment-platform-jenkins-ephemeral --force --data$' "${log_file}"
+assert_runtime_config_isolated_and_removed
+
+: >"${log_file}"
+if FAKE_PROFILE_NAME=investment-platform-jenkins-ephemeral \
+  FAKE_PROFILE_PRESENT=0 \
+  FAKE_FAIL_TARGET=trigger \
+  DOCKER_CONTEXT=caller-context \
+  DOCKER_HOST=unix:///caller/docker.sock \
+    "${repo_root}/platform/jenkins/scripts/run-ephemeral.sh" >/dev/null 2>&1; then
+  printf 'Jenkins run-ephemeral ignored a failed phase\n' >&2
+  exit 1
+fi
+grep -q '^colima delete investment-platform-jenkins-ephemeral --force --data$' "${log_file}"
+assert_runtime_config_isolated_and_removed
+
+printf 'Ephemeral-runtime lifecycle and context-isolation tests passed.\n'


### PR DESCRIPTION
## Summary

- isolate Docker and Kubernetes configuration before either disposable Colima VM starts
- ignore inherited `DOCKER_CONTEXT` and `DOCKER_HOST` values inside the isolated runners
- discard generated context records only after kind and Colima teardown
- add behavioral success and failure tests for local and Jenkins runners
- replace the stale Minikube disposition text with the supported kind workflow

## Verification

- `scripts/ci/test-local-runtime-cleanup.sh`
- `PRESUBMIT_REQUIRE_PR_CHECKLIST=false make presubmit-ps0`
- `PYTHON_BIN=/tmp/jenkins-quality-venv/bin/python make presubmit-ps1`
- real `make -C platform/local e2e-ephemeral` passed all three platform slices
- exact-head disposable Jenkins passed PS0, PS1, and PS2 for `4b72728`
- before/after comparisons for both real runners confirmed identical Docker
  context names, Kubernetes context names, and active context selections
- both teardowns left no Colima instance or container data

## Review checklist

- [x] `SCOPE` — limited to disposable runtime context isolation and its documentation
- [x] `TEST` — success, phase failure, and Colima-start failure paths are covered
- [x] `SEC` — caller Docker credentials and kubeconfig are never used by disposable workloads
- [x] `AUTH` — no workload authentication or authorization behavior changes
- [x] `DATA` — no application data, schema, or retention behavior changes
- [x] `DIST` — Kafka delivery, ordering, replay, and idempotency semantics are unchanged
- [x] `INFRA` — local and Jenkins kind lifecycles retain their existing profile boundaries
- [x] `OPS` — pre-existing contexts and profiles are never deleted or modified
